### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Tue Jan 15 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.0
 - Update documentation
 - Add acceptance tests for obtaining certs via CMC and certmonger
+- Update the upper bound of stdlib to < 6.0.0
 
 * Fri Dec 28 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.2.0
 - Minor breaking changes - Module still **experimental**

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ By default, to access the 389ds configuration, you would use the following:
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 If you find any issues, they can be submitted to our
 [JIRA](https://simp-project.atlassian.net).

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_pki_service