### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -27,7 +27,7 @@ on:
     types: [opened, reopened, synchronize]
 
 env:
-  PUPPET_VERSION: '~> 6'
+  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -50,7 +50,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -65,7 +65,7 @@ jobs:
       - name: "Install Ruby ${{matrix.puppet.ruby_version}}"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -76,10 +76,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install Ruby 2.5'
+      - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -92,7 +92,7 @@ jobs:
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
-            puppet_version: '~> 6.22.1'
-            ruby_version: '2.5'
-          - label: 'Puppet 7.x'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
+          - label: 'Puppet 8.x'
+            puppet_version: '~> 8.0'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jun 12 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.5.0
+- Add RockyLinux 8 support
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.4.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']

--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -106,7 +106,7 @@ define simp_pki_service::ca (
   Simp_pki_service::SecurityDomain $pki_security_domain,
   String[2]                        $admin_user                         = 'caadmin',
   String[1]                        $admin_password                     = simplib::passgen("${pki_security_domain}_${name}", { 'length' => 64, 'complexity' => 0 }),
-  Simplib::Hostname                $pki_security_domain_hostname       = $facts['fqdn'],
+  Simplib::Hostname                $pki_security_domain_hostname       = $facts['networking']['fqdn'],
   Simplib::Port                    $pki_security_domain_https_port     = 8443,
   Boolean                          $root_ca                            = false,
   String[2]                        $pki_security_domain_user           = $admin_user,
@@ -203,7 +203,7 @@ define simp_pki_service::ca (
 
   if $enable_kra or ( $ca_config['ca.scep.enable'] == true ) {
     if $create_subordinate_security_domain {
-      $_kra_pki_security_domain_hostname   = $facts['fqdn']
+      $_kra_pki_security_domain_hostname   = $facts['networking']['fqdn']
       $_kra_pki_security_domain_https_port = $https_port
       $_kra_pki_security_domain_user       = $admin_user
       $_kra_pki_security_domain_password   = $admin_password
@@ -228,7 +228,7 @@ define simp_pki_service::ca (
       pki_security_domain_hostname   => $_kra_pki_security_domain_hostname,
       pki_security_domain_https_port => $_kra_pki_security_domain_https_port,
       admin_password                 => $admin_password,
-      ca_hostname                    => $facts['fqdn'],
+      ca_hostname                    => $facts['networking']['fqdn'],
       ca_port                        => $https_port,
       admin_user                     => $admin_user,
       service_timeout                => $service_timeout,

--- a/manifests/directory_server.pp
+++ b/manifests/directory_server.pp
@@ -72,9 +72,9 @@ define simp_pki_service::directory_server (
     [General]
     SuiteSpotUserID=${service_user}
     SuiteSpotGroup=${service_group}
-    AdminDomain=${facts['domain']}
-    FullMachineName=${facts['fqdn']}
-    ConfigDirectoryLdapURL=ldap://${facts['fqdn']}:389/o=NetscapeRoot
+    AdminDomain=${facts['networking']['domain']}
+    FullMachineName=${facts['networking']['fqdn']}
+    ConfigDirectoryLdapURL=ldap://${facts['networking']['fqdn']}:389/o=NetscapeRoot
     ConfigDirectoryAdminID=${admin_user}
     ConfigDirectoryAdminPwd=${admin_password}
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class simp_pki_service (
   Simp_pki_service::SecurityDomain $pki_security_domain          = 'SIMP',
   Hash                             $ds_config                    = {
     'root_dn'        => "cn=${pki_security_domain} Directory Manager",
-    'base_dn'        => sprintf('ou=%s,%s',$pki_security_domain, simplib::ldap::domain_to_dn($facts['domain'], false)),
+    'base_dn'        => sprintf('ou=%s,%s',$pki_security_domain, simplib::ldap::domain_to_dn($facts['networking']['domain'], false)),
     'admin_password' => simplib::passgen('389-ds-simp-pki', {'length' => 64, 'complexity' => 0 })
   },
   Hash[String[1], Hash]            $cas                          = {

--- a/manifests/kra.pp
+++ b/manifests/kra.pp
@@ -90,7 +90,7 @@ define simp_pki_service::kra (
 
   ensure_packages('pki-kra', { ensure => $package_ensure })
 
-  $_fqdn = $facts['fqdn']
+  $_fqdn = $facts['networking']['fqdn']
   $_kra_config = @("KRA_CONFIG")
     # This file managed by Puppet
     [DEFAULT]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_pki_service",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "SIMP Team",
   "summary": "A SIMP module for setting up a SIMP-specific DogTag CA",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.18.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -32,6 +32,12 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
       ]
     }
   ],


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.